### PR TITLE
Workaround overlay bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,5 @@ ADD https://github.com/rancherio/swarm/releases/download/v0.1.0-rancher/swarm /u
 RUN chmod +x /usr/bin/swarm
 CMD ["/etc/init.d/agent-instance-startup", "init"]
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y racoon
+# Work around overlay bug
+RUN touch /etc/monit/conf.d/.hold


### PR DESCRIPTION
https://github.com/docker/docker/issues/13108

/etc/monit/conf.d is an empty folder in the base image.  Because it
is empty a rmdir /etc/monit/conf.d will delete the folder regardless
of whether it has files in it or not.  This causes tar extracts to
always delete /etc/monit/conf.d meaning that the folder only ever has
one config in it (which is bad)
