### PR TITLE
Bumped up haproxy version to 1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ibuildthecloud/ubuntu-core-base:14.04
 ADD http://stedolan.github.io/jq/download/linux64/jq /usr/bin/
 RUN chmod +x /usr/bin/jq
+RUN echo deb http://archive.ubuntu.com/ubuntu trusty-backports main universe | \
+      sudo tee /etc/apt/sources.list.d/backports.list
 RUN apt-get update && apt-get install -y \
     busybox \
     curl \
@@ -13,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     tcpdump \
     uuid-runtime \
     vim-tiny \
-    haproxy && \
+    haproxy -t trusty-backports && \
     rm -rf /var/lib/apt/lists
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 ADD startup.sh /etc/init.d/agent-instance-startup


### PR DESCRIPTION
As native SSL support was introduced in 1.5 only, and default haproxy version for the current image is 1.4.

@ibuildthecloud There is another way to point haproxy to the latest version - by enabling dedicated PPA for haproxy 1.5. And as add-apt-repository tool is not enabled by default, it should be enabled by installing "software-properties-common" package. Let me know if you prefer this way to backports one.
