### PR TITLE
Add logrotate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibuildthecloud/ubuntu-core-base:14.04
+FROM ubuntu:14.04.3
 ADD http://stedolan.github.io/jq/download/linux64/jq /usr/bin/
 RUN chmod +x /usr/bin/jq
 RUN echo deb http://archive.ubuntu.com/ubuntu trusty-backports main universe | \

--- a/startup.sh
+++ b/startup.sh
@@ -47,7 +47,21 @@ check_debug
 CONTENT_URL=/configcontent/configscripts
 INSTALL_ITEMS="configscripts agent-instance-startup"
 
+setup_logrotate()
+{
+    if [ -d '/etc/monit/conf.d' ]; then
 
+        cat > /etc/monit/conf.d/logrotate <<EOF
+check program logrotate with path /etc/cron.daily/logrotate 
+  with timeout 1800 seconds
+  every "0-25 6 * * *"
+  if status == 0 then exec /bin/true
+EOF
+
+        chmod 600 /etc/monit/conf.d/logrotate
+    fi
+}
+    
 call_curl()
 {
     local curl="curl -s" 
@@ -96,6 +110,7 @@ start()
     # Let scripts know its being ran during startup
     export CATTLE_AGENT_STARTUP=true
 
+    setup_logrotate
     setup_config_url
     download_agent
 }


### PR DESCRIPTION
This change adds logrotate to monit to run once a day. 

It also changes the base image from an older @ibuildthecloud image to upstream Ubuntu image.

To use logrotate, Rancher agent config scripts will just need to drop conf files into /etc/logrotate.d/
